### PR TITLE
Fixed Warning:

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,8 +61,10 @@ function App() {
     );
 }
 
-export default () => (
+const RootComponent = () => (
     <StyleProvider>
         <App />
     </StyleProvider>
-)
+);
+
+export default RootComponent;


### PR DESCRIPTION
Assign arrow function to a variable before exporting as module defaulteslintimport/no-anonymous-default-export